### PR TITLE
Fix CRA + Less modules test crash

### DIFF
--- a/lib/craco-antd.dev.test.js
+++ b/lib/craco-antd.dev.test.js
@@ -102,7 +102,7 @@ test("the webpack config is modified correctly with all options and Less vars", 
   expect(jsRule).not.toBeUndefined();
   expect(jsRule.options.plugins[1]).toEqual([
     "import",
-    { libraryName: "antd", libraryDirectory: "es", style: true }
+    { libraryName: "antd", libraryDirectory: "lib", style: true }
   ]);
 
   const lessRule = oneOfRules.oneOf.find(
@@ -192,7 +192,7 @@ test("the webpack config is modified correctly when loading vars from JSON file"
   expect(jsRule).not.toBeUndefined();
   expect(jsRule.options.plugins[1]).toEqual([
     "import",
-    { libraryName: "antd", libraryDirectory: "es", style: true }
+    { libraryName: "antd", libraryDirectory: "lib", style: true }
   ]);
 
   const lessRule = oneOfRules.oneOf.find(
@@ -281,7 +281,7 @@ const runExpectationsForMinimalConfiguration = () => {
   expect(jsRule).not.toBeUndefined();
   expect(jsRule.options.plugins[1]).toEqual([
     "import",
-    { libraryName: "antd", libraryDirectory: "es", style: true }
+    { libraryName: "antd", libraryDirectory: "lib", style: true }
   ]);
 
   const lessRule = oneOfRules.oneOf.find(

--- a/lib/craco-antd.js
+++ b/lib/craco-antd.js
@@ -87,7 +87,7 @@ module.exports = {
     // See: https://github.com/FormAPI/craco-antd/issues/3
     cracoConfig.babel.plugins.push([
       "import",
-      { libraryName: "antd", libraryDirectory: "es", style: true }
+      { libraryName: "antd", libraryDirectory: "lib", style: true }
     ]);
     return cracoConfig;
   }

--- a/lib/craco-antd.prod.test.js
+++ b/lib/craco-antd.prod.test.js
@@ -102,7 +102,7 @@ test("the webpack config is modified correctly with all options and Less vars", 
   expect(jsRule).not.toBeUndefined();
   expect(jsRule.options.plugins[1]).toEqual([
     "import",
-    { libraryName: "antd", libraryDirectory: "es", style: true }
+    { libraryName: "antd", libraryDirectory: "lib", style: true }
   ]);
 
   const lessRule = oneOfRules.oneOf.find(
@@ -189,7 +189,7 @@ test("the webpack config is modified correctly when loading vars from JSON file"
   expect(jsRule).not.toBeUndefined();
   expect(jsRule.options.plugins[1]).toEqual([
     "import",
-    { libraryName: "antd", libraryDirectory: "es", style: true }
+    { libraryName: "antd", libraryDirectory: "lib", style: true }
   ]);
 
   const lessRule = oneOfRules.oneOf.find(
@@ -275,7 +275,7 @@ const runExpectationsForMinimalConfiguration = () => {
   expect(jsRule).not.toBeUndefined();
   expect(jsRule.options.plugins[1]).toEqual([
     "import",
-    { libraryName: "antd", libraryDirectory: "es", style: true }
+    { libraryName: "antd", libraryDirectory: "lib", style: true }
   ]);
 
   const lessRule = oneOfRules.oneOf.find(


### PR DESCRIPTION
Right now if you use the following config
```
const path = require('path');

const CracoAntDesignPlugin = require("craco-antd");
const CracoLessPlugin = require('craco-less');

module.exports = {
  plugins: [
    {
      plugin: CracoLessPlugin,
      options: {
        lessLoaderOptions: {
          javascriptEnabled: true
        }
      }
    },
    {
      plugin: CracoAntDesignPlugin,
      options: {
        cssLoaderOptions: {
          modules: {
            localIdentName: '[local]_[hash:base64:5]'
          }
        },
        modifyLessRule: function (lessRule, _context) {
          lessRule.test = /\.(module)\.(less)$/;
          lessRule.exclude = /node_modules/;

          return lessRule;
        }
      }
    }
  ]
};
```
and hit `yarn test`, the test will fail and crash with the following error message
![image](https://user-images.githubusercontent.com/40416283/82541101-0d66bc80-9ba4-11ea-8cd0-61f35fdc5555.png)
I did some research and found out that if we replaced "es" with "lib" when configuring the Antd babel plugins, it'd fix the problem. I don't know why that works though :(