### PR TITLE
use less-loader@6.0.0 options format without overwrite issue

### DIFF
--- a/lib/craco-antd.dev.test.js
+++ b/lib/craco-antd.dev.test.js
@@ -55,8 +55,10 @@ test("the webpack config is modified correctly with all options and Less vars", 
         plugin: CracoAntDesignPlugin,
         options: {
           lessLoaderOptions: {
-            modifyVars: {
-              "@less-loader-options-priority": "#fff"
+            lessOptions: {
+              modifyVars: {
+                "@less-loader-options-priority": "#fff"
+              }
             }
           },
           customizeTheme: {
@@ -134,11 +136,13 @@ test("the webpack config is modified correctly with all options and Less vars", 
 
   expect(lessRule.use[4].loader).toContain(`${path.sep}less-loader`);
   expect(lessRule.use[4].options).toEqual({
-    javascriptEnabled: true,
-    modifyVars: {
-      "@antd-customize-json-priority": "#fff",
-      "@customize-theme-priority": "#fff",
-      "@less-loader-options-priority": "#fff"
+    lessOptions: {
+      javascriptEnabled: true,
+      modifyVars: {
+        "@antd-customize-json-priority": "#fff",
+        "@customize-theme-priority": "#fff",
+        "@less-loader-options-priority": "#fff"
+      }
     }
   });
 });
@@ -158,8 +162,10 @@ test("the webpack config is modified correctly when loading vars from JSON file"
         plugin: CracoAntDesignPlugin,
         options: {
           lessLoaderOptions: {
-            modifyVars: {
-              "@less-loader-options-priority": "#fff"
+            lessOptions: {
+              modifyVars: {
+                "@less-loader-options-priority": "#fff"
+              }
             }
           },
           customizeTheme: {
@@ -222,11 +228,13 @@ test("the webpack config is modified correctly when loading vars from JSON file"
 
   expect(lessRule.use[4].loader).toContain(`${path.sep}less-loader`);
   expect(lessRule.use[4].options).toEqual({
-    javascriptEnabled: true,
-    modifyVars: {
-      "@antd-customize-json-priority": "#fff",
-      "@customize-theme-priority": "#fff",
-      "@less-loader-options-priority": "#fff"
+    lessOptions: {
+      javascriptEnabled: true,
+      modifyVars: {
+        "@antd-customize-json-priority": "#fff",
+        "@customize-theme-priority": "#fff",
+        "@less-loader-options-priority": "#fff"
+      }
     }
   });
 });
@@ -300,8 +308,10 @@ const runExpectationsForMinimalConfiguration = () => {
 
   expect(lessRule.use[4].loader).toContain(`${path.sep}less-loader`);
   expect(lessRule.use[4].options).toEqual({
-    javascriptEnabled: true,
-    modifyVars: {}
+    lessOptions: {
+      javascriptEnabled: true,
+      modifyVars: {}
+    }
   });
 };
 

--- a/lib/craco-antd.js
+++ b/lib/craco-antd.js
@@ -51,14 +51,15 @@ const overrideWebpackConfig = ({ context, webpackConfig, pluginOptions }) => {
   }
 
   const lessLoaderOptions = pluginOptions.lessLoaderOptions || {};
-  if (lessLoaderOptions.modifyVars) {
-    Object.assign(modifyVars, lessLoaderOptions.modifyVars);
+  lessLoaderOptions.lessOptions = lessLoaderOptions.lessOptions || {};
+  if (lessLoaderOptions.lessOptions.modifyVars) {
+    Object.assign(modifyVars, lessLoaderOptions.lessOptions.modifyVars);
   }
 
-  lessLoaderOptions.modifyVars = modifyVars;
+  lessLoaderOptions.lessOptions.modifyVars = modifyVars;
   // javascriptEnabled: true is suggested in the Ant Design docs:
   // https://ant.design/docs/react/customize-theme#Customize-in-webpack
-  lessLoaderOptions.javascriptEnabled = true;
+  lessLoaderOptions.lessOptions.javascriptEnabled = true;
 
   return CracoLessPlugin.overrideWebpackConfig({
     context,

--- a/lib/craco-antd.prod.test.js
+++ b/lib/craco-antd.prod.test.js
@@ -55,8 +55,10 @@ test("the webpack config is modified correctly with all options and Less vars", 
         plugin: CracoAntDesignPlugin,
         options: {
           lessLoaderOptions: {
-            modifyVars: {
-              "@less-loader-options-priority": "#fff"
+            lessOptions: {
+              modifyVars: {
+                "@less-loader-options-priority": "#fff"
+              }
             }
           },
           customizeTheme: {
@@ -130,11 +132,13 @@ test("the webpack config is modified correctly with all options and Less vars", 
 
   expect(lessRule.use[4].loader).toContain(`${path.sep}less-loader`);
   expect(lessRule.use[4].options).toEqual({
-    javascriptEnabled: true,
-    modifyVars: {
-      "@less-loader-options-priority": "#fff",
-      "@customize-theme-priority": "#fff",
-      "@antd-customize-json-priority": "#fff"
+    lessOptions: {
+      javascriptEnabled: true,
+      modifyVars: {
+        "@less-loader-options-priority": "#fff",
+        "@customize-theme-priority": "#fff",
+        "@antd-customize-json-priority": "#fff"
+      }
     },
     sourceMap: true
   });
@@ -155,8 +159,10 @@ test("the webpack config is modified correctly when loading vars from JSON file"
         plugin: CracoAntDesignPlugin,
         options: {
           lessLoaderOptions: {
-            modifyVars: {
-              "@less-loader-options-priority": "#fff"
+            lessOptions: {
+              modifyVars: {
+                "@less-loader-options-priority": "#fff"
+              }
             }
           },
           customizeTheme: {
@@ -215,11 +221,13 @@ test("the webpack config is modified correctly when loading vars from JSON file"
 
   expect(lessRule.use[4].loader).toContain(`${path.sep}less-loader`);
   expect(lessRule.use[4].options).toEqual({
-    javascriptEnabled: true,
-    modifyVars: {
-      "@less-loader-options-priority": "#fff",
-      "@customize-theme-priority": "#fff",
-      "@antd-customize-json-priority": "#fff"
+    lessOptions: {
+      javascriptEnabled: true,
+      modifyVars: {
+        "@less-loader-options-priority": "#fff",
+        "@customize-theme-priority": "#fff",
+        "@antd-customize-json-priority": "#fff"
+      }
     },
     sourceMap: true
   });
@@ -289,8 +297,10 @@ const runExpectationsForMinimalConfiguration = () => {
 
   expect(lessRule.use[4].loader).toContain(`${path.sep}less-loader`);
   expect(lessRule.use[4].options).toEqual({
-    javascriptEnabled: true,
-    modifyVars: {},
+    lessOptions: {
+      javascriptEnabled: true,
+      modifyVars: {}
+    },
     sourceMap: true
   });
 };


### PR DESCRIPTION
This is to update options for less-loader@6.0.0 expectation:

https://github.com/ant-design/ant-design/issues/23624#issuecomment-625381410

Done all coverage and audit commands.