### PR TITLE
Allow CRA 4 in peer deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "peerDependencies": {
     "@craco/craco": "^5.5.0",
     "antd": ">= 3.0.0",
-    "react-scripts": "^3.4.3"
+    "react-scripts": "^3.4.3 || ^4.0.0"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "babel-plugin-import": "^1.13.1",
-    "craco-less": "1.17.0",
+    "craco-less": "^1.17.0",
     "less-vars-to-js": "^1.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
The plugin works well for me with Craco 5.8.0 and CRA 4. It would be nice to allow CRA 4 in peer deps.
