### PR TITLE
Updates craco-less to 2.0.0 for CRA 5 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "dependencies": {
     "babel-plugin-import": "^1.13.1",
-    "craco-less": "1.17.0",
+    "craco-less": "2.0.0",
     "less-vars-to-js": "^1.3.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
Updates craco-less to 2.0.0 to fix errors with CRA 5.
Otherwise we have to force-resolve craco-less to 2.0.0 to get around this.