### PR TITLE
Upgrade to craco@7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "less-vars-to-js": "1.3.0"
   },
   "peerDependencies": {
-    "@craco/craco": "6.4.3",
+    "@craco/craco": "7.1.0",
     "antd": ">=3.0.0",
     "react-scripts": "5.0.1"
   },


### PR DESCRIPTION
craco does not support react-scripts 5.x in 6.x version. We need to update to 7.x version in order to properly support this. This peer-dependency doesn't make sense as it's conflicting with craco.